### PR TITLE
Remove unused USER_ID environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ CLI agent template built with Bun + TypeScript. Provides an interactive chat int
 
 - `agent.ts` — CLI entry point (Commander.js). Single `chat` command with `-t, --toolkits` option
 - `classes/wrappedAgent.ts` — Abstract base agent with streaming, conversation history, interactive REPL
-- `classes/config.ts` — Loads required env vars: `OPENAI_API_KEY`, `OPENAI_MODEL`, `LOG_LEVEL`, `ARCADE_API_KEY`, `USER_ID`
+- `classes/config.ts` — Loads required env vars: `OPENAI_API_KEY`, `OPENAI_MODEL`, `LOG_LEVEL`
 - `classes/logger.ts` — Logging with levels, colors (chalk), spinners (ora), tool call tracking
 - `agents/general.ts` — Main agent implementation extending WrappedAgent
 - `utils/tools.ts` — Arcade.dev toolkit → OpenAI agent tool conversion

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -13,7 +13,6 @@ describe("Logger", () => {
     process.env.OPENAI_MODEL = "gpt-4-turbo";
     process.env.LOG_LEVEL = "info";
     process.env.ARCADE_API_KEY = "test-arcade-key";
-    process.env.USER_ID = "test-user-id";
 
     // Mock console methods to capture output
     console.log = () => {};


### PR DESCRIPTION
## Summary

Removed stale references to USER_ID environment variable that was previously removed from config.ts. Updated CLAUDE.md documentation and test setup to match the actual implementation.

## Changes

- `CLAUDE.md` — Updated env vars list to remove `ARCADE_API_KEY` and `USER_ID`
- `tests/logger.test.ts` — Removed `USER_ID` from test setup

All tests pass ✓