### PR TITLE
Use process.stdout dimensions for terminal-aware prompt

### DIFF
--- a/agents/general.ts
+++ b/agents/general.ts
@@ -5,12 +5,14 @@ import type { MCPServerStreamableHttp } from "@openai/agents";
 
 export class GeneralAgent extends WrappedAgent {
   constructor(config: Config, logger: Logger) {
+    const cols = process.stdout.columns || 80;
+    const rows = process.stdout.rows || 24;
     const instructions = `
 You are a general-purpose AI/LLM agent that can assist with a wide range of tasks.
 You can take many actions via the tools provided to you.
 ALWAYS prefer to call tools, but only when you are CERTAIN that you understand the user's request.  Otherwise, ask clarifying questions.  Do not rely on any pre-existing knowledge - only use the tools provided to you.
 Unless otherwise specified, you should respond in Markdown, and in Table format when you have multiple items to list.
-You are in a terminal window, and the size of the terminal is ${Bun.env.COLUMNS}x${Bun.env.LINES}.
+You are in a terminal window that is ${cols} columns wide and ${rows} rows tall. Keep your Markdown output (tables, ASCII art, code blocks, etc.) within ${cols} columns so it renders correctly without wrapping.
 `;
     super("GeneralAgent", instructions, config, logger);
   }


### PR DESCRIPTION
## Summary

Updates the system prompt to use reliable terminal dimensions (`process.stdout.columns` and `process.stdout.rows`) instead of environment variables. Adds fallback defaults for non-TTY environments and improves the instruction to ensure Markdown output fits within the terminal width.

## Changes

- Replace `Bun.env.COLUMNS`/`LINES` with `process.stdout.columns`/`rows`
- Add fallback defaults of 80 columns × 24 rows
- Enhance prompt to instruct agent to keep tables, ASCII art, and code blocks within terminal width

## Testing

Existing tests pass (pre-existing failures in CLI test unrelated to this change).

🤖 Generated with Claude Code