### PR TITLE
Add MCP URL to system prompt for server introspection

### DIFF
--- a/agents/general.ts
+++ b/agents/general.ts
@@ -7,10 +7,15 @@ export class GeneralAgent extends WrappedAgent {
   constructor(config: Config, logger: Logger) {
     const cols = process.stdout.columns || 80;
     const rows = process.stdout.rows || 24;
+    const mcpSection = config.arcade_gateway_url
+      ? `\n## MCP Server\nYou are connected to an MCP server at: ${config.arcade_gateway_url}\n`
+      : "";
+
     const instructions = `
 You are a general-purpose AI/LLM agent that can assist with a wide range of tasks.
 You can take many actions via the tools provided to you.
 ALWAYS prefer to call tools, but only when you are CERTAIN that you understand the user's request.  Otherwise, ask clarifying questions.  Do not rely on any pre-existing knowledge - only use the tools provided to you.
+${mcpSection}
 
 ## Response Formatting (IMPORTANT)
 You MUST format ALL responses using Markdown. This is critical — your output is rendered through a Markdown engine in the terminal, so raw text without Markdown formatting will look plain and unhelpful. Specifically:


### PR DESCRIPTION
The agent now knows what MCP server it's connected to by including the Arcade gateway URL in its system prompt. This enables introspection capabilities and better context awareness of available tools.

When an MCP server URL is configured, a "## MCP Server" section is added to the agent's instructions with the gateway URL. This allows the agent to understand its connection context without relying on external knowledge.