### PR TITLE
Add escape key to cancel agent response

### DIFF
--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -9,10 +9,12 @@ interface InputBoxProps {
   contextDir: string;
   queueCount: number;
   focus: boolean;
+  isStreaming: boolean;
   onToggleFocus: () => void;
   onScroll: (direction: "left" | "right") => void;
   onScrollVertical: (direction: "up" | "down") => void;
   onReturnToInput: () => void;
+  onCancel: () => void;
 }
 
 const DELIM = "\0";
@@ -36,10 +38,12 @@ export function InputBox({
   contextDir,
   queueCount,
   focus,
+  isStreaming,
   onToggleFocus,
   onScroll,
   onScrollVertical,
   onReturnToInput,
+  onCancel,
 }: InputBoxProps) {
   const [value, setValue] = useState("");
   const historyFile = path.join(contextDir, "chat_history.txt");
@@ -63,6 +67,11 @@ export function InputBox({
   );
 
   useInput((input, key) => {
+    if (key.escape && isStreaming) {
+      onCancel();
+      return;
+    }
+
     if (key.tab) {
       onToggleFocus();
       return;

--- a/components/MessageArea.tsx
+++ b/components/MessageArea.tsx
@@ -94,6 +94,10 @@ export function MessageArea({
                     ` 🕝 ${Math.round((Date.now() - startTime) / 1000)}s`}
                   {toolCallCount > 0 &&
                     ` | 🛠️ ${toolCallCount} tool call${toolCallCount > 1 ? "s" : ""}`}
+                  {" | "}
+                </Text>
+                <Text color="yellow" dimColor>
+                  [esc] to cancel
                 </Text>
               </Box>
               {streamingText && <Text>{renderMarkdown(streamingText)}</Text>}


### PR DESCRIPTION
## Summary

- Add Escape key binding to cancel streaming agent responses
- Show "[esc] to cancel" hint in the UI while streaming
- Preserve partial responses and display a red cancellation message

## Test plan

- [ ] Start the agent and press Escape while a response is streaming
- [ ] Verify partial response is preserved (if any text was received)
- [ ] Verify red "Response cancelled." message appears
- [ ] Verify tests pass: `bun test`
- [ ] Verify lint passes: `bun lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)